### PR TITLE
Make `unquoteIfQuoted` a generic function to avoid casting

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1871,7 +1871,7 @@ func (d *Decimal) Scan(value interface{}) error {
 		return err
 
 	default:
-		return fmt.Errorf("could not convert value '%+v' to byte array of type '%T'", v, v)
+		return fmt.Errorf("could not convert value '%+v' of type '%T'", v, v)
 	}
 }
 

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -248,3 +248,15 @@ func BenchmarkDecimal_ExpTaylor(b *testing.B) {
 		_, _ = d.ExpTaylor(10)
 	}
 }
+
+func BenchmarkDecimal_UnmarshalJSON(b *testing.B) {
+	b.ResetTimer()
+
+	data := []byte(`100.0000`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = (&Decimal{}).UnmarshalJSON(data)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/advbet/xdecimal/v2
 
-go 1.13
+go 1.18
 
 require github.com/stretchr/testify v1.8.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
Our organization heavily relies on this package for all kinds of decimal operations. We do a lot of operations related to JSON parsing. As a low-hanging fruit for optimizations, we can start by making `unquoteIfQuoted` a generic function.
This function was causing unnecessary allocations by doing `v := value.(type)` casting. Making this function generic seems to give some performance.
Benchmarks show there's about 16% speedup

Benchmarks
Before:
```
goos: darwin
goarch: arm64
pkg: github.com/advbet/xdecimal/v2
cpu: Apple M1 Pro
BenchmarkDecimal_UnmarshalJSON-8   	 8665200	       130.8 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 8990174	       131.7 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 9205892	       130.3 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 9095335	       130.3 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 9113773	       134.5 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 9128460	       131.4 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 8823780	       137.7 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 8578131	       154.7 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 8883667	       134.3 ns/op	      80 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	 9244027	       133.1 ns/op	      80 B/op	       5 allocs/op
PASS
ok  	github.com/advbet/xdecimal/v2	13.669s
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/advbet/xdecimal/v2
cpu: Apple M1 Pro
BenchmarkDecimal_UnmarshalJSON-8   	10049608	       112.0 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10732308	       113.8 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10185679	       138.7 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10644686	       110.5 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10641768	       110.8 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10746822	       110.5 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10720071	       110.9 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10639095	       110.9 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10615526	       111.1 ns/op	      56 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8   	10766797	       111.6 ns/op	      56 B/op	       4 allocs/op
PASS
ok  	github.com/advbet/xdecimal/v2	13.428s
```
Diff:
```
                        │ bench1.txt  │             bench2.txt              │
                        │   sec/op    │   sec/op     vs base                │
Decimal_UnmarshalJSON-8   132.4n ± 4%   111.0n ± 3%  -16.16% (p=0.001 n=10)

                        │ bench1.txt │             bench2.txt             │
                        │    B/op    │    B/op     vs base                │
Decimal_UnmarshalJSON-8   80.00 ± 0%   56.00 ± 0%  -30.00% (p=0.000 n=10)

                        │ bench1.txt │             bench2.txt             │
                        │ allocs/op  │ allocs/op   vs base                │
Decimal_UnmarshalJSON-8   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
```
