### PR TITLE
Remove deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ provide additional features that original package did not provide.
 Here are the notable differences:
 - Trailing zeroes are not removed by default (except StringTrimZeros method, was introduced to do not mess with runtime variables when xdecimal is imported)
 - Zero value has exponent of 0
-- By default decimal is marshaled to JSON as a number
+- By default, decimal is marshaled to JSON as a number
+- Removed deprecated methods like `Equals` and `StringScaled`
 
 # decimal
 

--- a/decimal.go
+++ b/decimal.go
@@ -1317,11 +1317,6 @@ func (d Decimal) Equal(d2 Decimal) bool {
 	return d.Cmp(d2) == 0
 }
 
-// Equals is deprecated, please use Equal method instead
-func (d Decimal) Equals(d2 Decimal) bool {
-	return d.Equal(d2)
-}
-
 // GreaterThan (GT) returns true when d is greater than d2.
 func (d Decimal) GreaterThan(d2 Decimal) bool {
 	return d.Cmp(d2) == 1
@@ -1902,12 +1897,6 @@ func (d Decimal) GobEncode() ([]byte, error) {
 // GobDecode implements the gob.GobDecoder interface for gob serialization.
 func (d *Decimal) GobDecode(data []byte) error {
 	return d.UnmarshalBinary(data)
-}
-
-// StringScaled first scales the decimal then calls .String() on it.
-// NOTE: buggy, unintuitive, and DEPRECATED! Use StringFixed instead.
-func (d Decimal) StringScaled(exp int32) string {
-	return d.rescale(exp).String()
 }
 
 func (d Decimal) string(trimTrailingZeros bool) string {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1160,12 +1160,6 @@ func TestDecimal_rescale(t *testing.T) {
 				s, d.String(),
 				d.value.String(), d.exp)
 		}
-
-		// test StringScaled
-		s2 := New(input.int, input.exp).StringScaled(input.rescale)
-		if s2 != s {
-			t.Errorf("expected %s, got %s", s, s2)
-		}
 	}
 }
 
@@ -1833,9 +1827,6 @@ func TestDecimal_Uninitialized(t *testing.T) {
 		}
 		if d.StringFixed(3) != "0.000" {
 			t.Errorf("expected 0, got %s", d.StringFixed(3))
-		}
-		if d.StringScaled(-2) != "0" {
-			t.Errorf("expected 0, got %s", d.StringScaled(-2))
 		}
 	}
 
@@ -2766,12 +2757,6 @@ func TestDecimal_Equalities(t *testing.T) {
 	if a.Equal(c) {
 		t.Errorf("%q should not equal %q", a, c)
 	}
-
-	// note, this block should be deprecated, here for backwards compatibility
-	if !a.Equals(b) {
-		t.Errorf("%q should equal %q", a, b)
-	}
-
 	if !c.GreaterThan(b) {
 		t.Errorf("%q should be greater than  %q", c, b)
 	}
@@ -3428,7 +3413,7 @@ func TestNullDecimal_Scan(t *testing.T) {
 		// Scan succeeded... test resulting values
 		if !a.Valid {
 			t.Errorf("%s is null", a.Decimal)
-		} else if !a.Decimal.Equals(expected) {
+		} else if !a.Decimal.Equal(expected) {
 			t.Errorf("%s does not equal to %s", a.Decimal, expected)
 		}
 	}
@@ -3447,7 +3432,7 @@ func TestNullDecimal_Scan(t *testing.T) {
 		// Scan succeeded... test resulting values
 		if !a.Valid {
 			t.Errorf("%s is null", a.Decimal)
-		} else if !a.Decimal.Equals(expected) {
+		} else if !a.Decimal.Equal(expected) {
 			t.Errorf("%v does not equal %v", a, expected)
 		}
 	}
@@ -3470,7 +3455,7 @@ func TestNullDecimal_Scan(t *testing.T) {
 		// Scan succeeded... test resulting values
 		if !a.Valid {
 			t.Errorf("%s is null", a.Decimal)
-		} else if !a.Decimal.Equals(expected) {
+		} else if !a.Decimal.Equal(expected) {
 			t.Errorf("%v does not equal %v", a, expected)
 		}
 	}
@@ -3489,7 +3474,7 @@ func TestNullDecimal_Scan(t *testing.T) {
 		// Scan succeeded... test resulting values
 		if !a.Valid {
 			t.Errorf("%s is null", a.Decimal)
-		} else if !a.Decimal.Equals(expected) {
+		} else if !a.Decimal.Equal(expected) {
 			t.Errorf("%v does not equal %v", a, expected)
 		}
 	}
@@ -3542,7 +3527,7 @@ func TestBinary(t *testing.T) {
 		}
 
 		// The restored decimal should equal the original
-		if !d1.Equals(d2) {
+		if !d1.Equal(d2) {
 			t.Errorf("expected %v when restoring, got %v", d1, d2)
 		}
 	}
@@ -3562,7 +3547,7 @@ func TestBinary_Zero(t *testing.T) {
 		t.Errorf("error unmarshalling from binary: %v", err)
 	}
 
-	if !d1.Equals(d2) {
+	if !d1.Equal(d2) {
 		t.Errorf("expected %v when restoring, got %v", d1, d2)
 	}
 }


### PR DESCRIPTION
This removes deprecated methods that came from `shopspring/decimal` fork. As nobody apart from us is probably using this library, it's safe to remove these methods. If we use these deprecated functions, we can update as we update the xdecimal package.