### PR TITLE
Add `NewFromByteString` function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        version: ['1.19', '1.20', '1.21', '1.22']
+        version: ['1.19', '1.20', '1.21', '1.22', '1.23', '1.24']
 
     name: Go ${{ matrix.version }}
     steps:

--- a/decimal.go
+++ b/decimal.go
@@ -183,7 +183,7 @@ func NewFromRat(r *big.Rat, e int) Decimal {
 //
 // Example:
 //
-//	d, err := NewFromByteString([]byte("-123.45")
+//	d, err := NewFromByteString([]byte("-123.45"))
 //	d2, err := NewFromByteString([]byte(".0001"))
 //	d3, err := NewFromByteString([]byte("1.47000"))
 func NewFromByteString(valueBytes []byte) (Decimal, error) {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -251,6 +251,43 @@ func TestNewFromString(t *testing.T) {
 	}
 }
 
+func TestNewFromByteString(t *testing.T) {
+	for _, x := range testTable {
+		s := x.short
+		d, err := NewFromByteString([]byte(s))
+		if err != nil {
+			t.Errorf("error while parsing %s", s)
+		} else if d.String() != s {
+			t.Errorf("expected %s, got %s (%s, %d)",
+				s, d.String(),
+				d.value.String(), d.exp)
+		}
+	}
+
+	for _, x := range testTable {
+		s := x.exact
+		d, err := NewFromByteString([]byte(s))
+		if err != nil {
+			t.Errorf("error while parsing %s", s)
+		} else if d.String() != s {
+			t.Errorf("expected %s, got %s (%s, %d)",
+				s, d.String(),
+				d.value.String(), d.exp)
+		}
+	}
+
+	for e, s := range testTableScientificNotation {
+		d, err := NewFromByteString([]byte(s))
+		if err != nil {
+			t.Errorf("error while parsing %s", e)
+		} else if d.String() != s {
+			t.Errorf("expected %s, got %s (%s, %d)",
+				s, d.String(),
+				d.value.String(), d.exp)
+		}
+	}
+}
+
 func TestDecimal_StringTrimZeros(t *testing.T) {
 	val := RequireFromString("123.4500").StringTrimZeros()
 	if val != "123.45" {


### PR DESCRIPTION
This adds a new `NewFrom` variant to create a new `Decimal` from `[]byte` slice. This implementation is pretty much identical to NewFromString, but it uses `bytes` package to perform operations. Such change brings about ~30% performance improvements when unmarshaling from JSON bytes.

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/advbet/xdecimal/v2
cpu: Apple M1 Pro
BenchmarkDecimal_UnmarshalJSON-8        10130881               117.3 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10119884               127.9 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10431146               118.6 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10292587               116.1 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10321528               118.4 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10255916               116.4 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8         8572479               118.2 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10203463               119.5 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10335564               116.1 ns/op            56 B/op          4 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        10275778               119.9 ns/op            56 B/op          4 allocs/op
PASS
ok      github.com/advbet/xdecimal/v2   13.420s
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/advbet/xdecimal/v2
cpu: Apple M1 Pro
BenchmarkDecimal_UnmarshalJSON-8        11835325                89.91 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13168042                89.66 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13081032                89.86 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13167730                88.93 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        12639211                89.72 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13571320                89.55 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13378546                91.73 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        12933861                89.92 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13345034                90.77 ns/op           48 B/op          3 allocs/op
BenchmarkDecimal_UnmarshalJSON-8        13258342                88.82 ns/op           48 B/op          3 allocs/op
PASS
ok      github.com/advbet/xdecimal/v2   12.885s
```

Comparison
```
goos: darwin
goarch: arm64
pkg: github.com/advbet/xdecimal/v2
cpu: Apple M1 Pro
                        │ bench1.txt  │              bench2.txt              │
                        │   sec/op    │    sec/op     vs base                │
Decimal_UnmarshalJSON-8   89.79n ± 1%   118.30n ± 2%  +31.75% (p=0.000 n=10)

                        │ bench1.txt │             bench2.txt             │
                        │    B/op    │    B/op     vs base                │
Decimal_UnmarshalJSON-8   48.00 ± 0%   56.00 ± 0%  +16.67% (p=0.000 n=10)

                        │ bench1.txt │             bench2.txt             │
                        │ allocs/op  │ allocs/op   vs base                │
Decimal_UnmarshalJSON-8   3.000 ± 0%   4.000 ± 0%  +33.33% (p=0.000 n=10)
```
